### PR TITLE
Fixing build (bad version of parent)

### DIFF
--- a/hudsonbook-content/pom.xml
+++ b/hudsonbook-content/pom.xml
@@ -3,7 +3,7 @@
   <parent>
 	<groupId>com.wakaleo.hudsonbook</groupId>
 	<artifactId>hudsonbook</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>0.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>hudsonbook-content</artifactId>
   <packaging>jar</packaging>


### PR DESCRIPTION
Fixing build: this submodule was referencing a different version of the parent (1.0.0-SNAPSHOT) than the one from the directory above & current reactor (0.0.4-SNAPSHOT).
